### PR TITLE
turned subscribers in to HashMap with addr as key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ whatever messages are sent to channels they're subscribed to.
 
 Known bugs:
 
-- The server doesn't properly clean up the subscribers lists when a client
-  closes the connection.
+- The server doesn't properly clean up the channel lists when a client
+  closes the connection. 


### PR DESCRIPTION
The README stated that 
"The server doesn't properly clean up the subscribers lists when a client closes the connection."
Now it does.
The ChannelMap may have empty Channels.